### PR TITLE
Working integration tests

### DIFF
--- a/x-pack/plugins/case/server/common/models/commentable_case.ts
+++ b/x-pack/plugins/case/server/common/models/commentable_case.ts
@@ -292,9 +292,12 @@ export class CommentableCase {
 
       return CaseResponseRt.encode({
         ...caseResponse,
-        comments: flattenCommentSavedObjects(subCaseComments.saved_objects),
+        // Do we always want to return the parent's comments? This might be too much data so I'm going to mark this as
+        // undefined
+        comments: undefined,
         subCases: [
           flattenSubCaseSavedObject({
+            comments: subCaseComments.saved_objects,
             savedObject: this.subCase,
             totalAlerts: countAlertsForID({ comments: subCaseComments, id: this.subCase.id }),
           }),

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/delete_comment.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/delete_comment.ts
@@ -101,15 +101,15 @@ export default ({ getService }: FtrProviderContext): void => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         await supertest
           .delete(
-            `${CASES_URL}/${caseInfo.id}/comments/${caseInfo.subCase!.comments![0].id}?subCaseID=${
-              caseInfo.subCase!.id
-            }`
+            `${CASES_URL}/${caseInfo.id}/comments/${
+              caseInfo.subCases![0].comments![0].id
+            }?subCaseId=${caseInfo.subCases![0].id}`
           )
           .set('kbn-xsrf', 'true')
           .send()
           .expect(204);
         const { body } = await supertest.get(
-          `${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`
+          `${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`
         );
         expect(body.length).to.eql(0);
       });
@@ -117,24 +117,24 @@ export default ({ getService }: FtrProviderContext): void => {
       it('deletes all comments from a sub case', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         await supertest
-          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`)
+          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send(postCommentUserReq)
           .expect(200);
 
         let { body: allComments } = await supertest.get(
-          `${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`
+          `${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`
         );
         expect(allComments.length).to.eql(2);
 
         await supertest
-          .delete(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`)
+          .delete(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send()
           .expect(204);
 
         ({ body: allComments } = await supertest.get(
-          `${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`
+          `${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`
         ));
 
         // no comments for the sub case

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/find_comments.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/find_comments.ts
@@ -126,13 +126,13 @@ export default ({ getService }: FtrProviderContext): void => {
       it('finds comments for a sub case', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         await supertest
-          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`)
+          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send(postCommentUserReq)
           .expect(200);
 
         const { body: subCaseComments }: { body: CommentsResponse } = await supertest
-          .get(`${CASES_URL}/${caseInfo.id}/comments/_find?subCaseID=${caseInfo.subCase!.id}`)
+          .get(`${CASES_URL}/${caseInfo.id}/comments/_find?subCaseId=${caseInfo.subCases![0].id}`)
           .send()
           .expect(200);
         expect(subCaseComments.total).to.be(2);

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/get_all_comments.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/get_all_comments.ts
@@ -83,13 +83,13 @@ export default ({ getService }: FtrProviderContext): void => {
     it('should get comments from a sub cases', async () => {
       const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
       await supertest
-        .post(`${CASES_URL}/${caseInfo.subCase!.id}/comments`)
+        .post(`${CASES_URL}/${caseInfo.subCases![0].id}/comments`)
         .set('kbn-xsrf', 'true')
         .send(postCommentUserReq)
         .expect(200);
 
       const { body: comments } = await supertest
-        .get(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`)
+        .get(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
         .expect(200);
 
       expect(comments.length).to.eql(2);

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/get_comment.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/get_comment.ts
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext): void => {
     it('should get a sub case comment', async () => {
       const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
       const { body: comment }: { body: CommentResponse } = await supertest
-        .get(`${CASES_URL}/${caseInfo.id}/comments/${caseInfo.subCase!.comments![0].id}`)
+        .get(`${CASES_URL}/${caseInfo.id}/comments/${caseInfo.subCases![0].comments![0].id}`)
         .expect(200);
       expect(comment.type).to.be(CommentType.generatedAlert);
     });

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/patch_comment.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/patch_comment.ts
@@ -54,14 +54,14 @@ export default ({ getService }: FtrProviderContext): void => {
       it('patches a comment for a sub case', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         const { body: patchedSubCase }: { body: CaseResponse } = await supertest
-          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCases[0]!.id}`)
+          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send(postCommentUserReq)
           .expect(200);
 
         const newComment = 'Well I decided to update my comment. So what? Deal with it.';
         const { body: patchedSubCaseUpdatedComment } = await supertest
-          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCases[0].id}`)
+          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send({
             id: patchedSubCase.subCases![0].comments![1].id,
@@ -71,22 +71,22 @@ export default ({ getService }: FtrProviderContext): void => {
           })
           .expect(200);
 
-        expect(patchedSubCaseUpdatedComment.subCase.comments.length).to.be(2);
-        expect(patchedSubCaseUpdatedComment.subCase.comments[0].type).to.be(
+        expect(patchedSubCaseUpdatedComment.subCases![0].comments.length).to.be(2);
+        expect(patchedSubCaseUpdatedComment.subCases![0].comments[0].type).to.be(
           CommentType.generatedAlert
         );
-        expect(patchedSubCaseUpdatedComment.subCase.comments[1].type).to.be(CommentType.user);
-        expect(patchedSubCaseUpdatedComment.subCase.comments[1].comment).to.be(newComment);
+        expect(patchedSubCaseUpdatedComment.subCases![0].comments[1].type).to.be(CommentType.user);
+        expect(patchedSubCaseUpdatedComment.subCases![0].comments[1].comment).to.be(newComment);
       });
 
       it('fails to update the generated alert comment type', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         await supertest
-          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCases[0].id}`)
+          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send({
-            id: caseInfo.subCases[0].comments![0].id,
-            version: caseInfo.subCases[0].comments![0].version,
+            id: caseInfo.subCases![0].comments![0].id,
+            version: caseInfo.subCases![0].comments![0].version,
             type: CommentType.alert,
             alertId: 'test-id',
             index: 'test-index',
@@ -101,11 +101,11 @@ export default ({ getService }: FtrProviderContext): void => {
       it('fails to update the generated alert comment by using another generated alert comment', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
         await supertest
-          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCases[0].id}`)
+          .patch(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send({
-            id: caseInfo.subCases[0].comments![0].id,
-            version: caseInfo.subCases[0].comments![0].version,
+            id: caseInfo.subCases![0].comments![0].id,
+            version: caseInfo.subCases![0].comments![0].version,
             type: CommentType.generatedAlert,
             alerts: [{ _id: 'id1' }],
             index: 'test-index',

--- a/x-pack/test/case_api_integration/basic/tests/cases/comments/post_comment.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/comments/post_comment.ts
@@ -393,13 +393,13 @@ export default ({ getService }: FtrProviderContext): void => {
         // create another sub case just to make sure we get the right comments
         await createSubCase({ supertest, actionID });
         await supertest
-          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseID=${caseInfo.subCase!.id}`)
+          .post(`${CASES_URL}/${caseInfo.id}/comments?subCaseId=${caseInfo.subCases![0].id}`)
           .set('kbn-xsrf', 'true')
           .send(postCommentUserReq)
           .expect(200);
 
         const { body: subCaseComments }: { body: CommentsResponse } = await supertest
-          .get(`${CASES_URL}/${caseInfo.id}/comments/_find?subCaseID=${caseInfo.subCase!.id}`)
+          .get(`${CASES_URL}/${caseInfo.id}/comments/_find?subCaseId=${caseInfo.subCases![0].id}`)
           .send()
           .expect(200);
         expect(subCaseComments.total).to.be(2);

--- a/x-pack/test/case_api_integration/basic/tests/cases/delete_cases.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/delete_cases.ts
@@ -104,7 +104,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       it('should delete the sub cases when deleting a collection', async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
-        expect(caseInfo.subCase?.id).to.not.eql(undefined);
+        expect(caseInfo.subCases![0].id).to.not.eql(undefined);
 
         const { body } = await supertest
           .delete(`${CASES_URL}?ids=["${caseInfo.id}"]`)
@@ -114,20 +114,20 @@ export default ({ getService }: FtrProviderContext): void => {
 
         expect(body).to.eql({});
         await supertest
-          .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+          .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
           .send()
           .expect(404);
       });
 
       it(`should delete a sub case's comments when that case gets deleted`, async () => {
         const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
-        expect(caseInfo.subCase?.id).to.not.eql(undefined);
+        expect(caseInfo.subCases![0].id).to.not.eql(undefined);
 
         // there should be two comments on the sub case now
         const { body: patchedCaseWithSubCase }: { body: CaseResponse } = await supertest
           .post(`${CASES_URL}/${caseInfo.id}/comments`)
           .set('kbn-xsrf', 'true')
-          .query({ subCaseID: caseInfo.subCases[0].id })
+          .query({ subCaseId: caseInfo.subCases![0].id })
           .send(postCommentUserReq)
           .expect(200);
 

--- a/x-pack/test/case_api_integration/basic/tests/cases/find_cases.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/find_cases.ts
@@ -265,8 +265,8 @@ export default ({ getService }: FtrProviderContext): void => {
             supertest,
             cases: [
               {
-                id: collection.newSubCaseInfo.subCase!.id,
-                version: collection.newSubCaseInfo.subCase!.version,
+                id: collection.newSubCaseInfo.subCases![0].id,
+                version: collection.newSubCaseInfo.subCases![0].version,
                 status: CaseStatuses['in-progress'],
               },
             ],
@@ -356,7 +356,7 @@ export default ({ getService }: FtrProviderContext): void => {
       it('correctly counts stats including a collection without sub cases', async () => {
         // delete the sub case on the collection so that it doesn't have any sub cases
         await supertest
-          .delete(`${SUB_CASES_PATCH_DEL_URL}?ids=["${collection.newSubCaseInfo.subCase!.id}"]`)
+          .delete(`${SUB_CASES_PATCH_DEL_URL}?ids=["${collection.newSubCaseInfo.subCases![0].id}"]`)
           .set('kbn-xsrf', 'true')
           .send()
           .expect(204);

--- a/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/delete_sub_cases.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/delete_sub_cases.ts
@@ -40,10 +40,10 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('should delete a sub case', async () => {
       const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
-      expect(caseInfo.subCase?.id).to.not.eql(undefined);
+      expect(caseInfo.subCases![0].id).to.not.eql(undefined);
 
       const { body: subCase } = await supertest
-        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
         .send()
         .expect(200);
 
@@ -57,20 +57,20 @@ export default function ({ getService }: FtrProviderContext) {
 
       expect(body).to.eql({});
       await supertest
-        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
         .send()
         .expect(404);
     });
 
     it(`should delete a sub case's comments when that case gets deleted`, async () => {
       const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
-      expect(caseInfo.subCase?.id).to.not.eql(undefined);
+      expect(caseInfo.subCases![0].id).to.not.eql(undefined);
 
       // there should be two comments on the sub case now
       const { body: patchedCaseWithSubCase }: { body: CaseResponse } = await supertest
         .post(`${CASES_URL}/${caseInfo.id}/comments`)
         .set('kbn-xsrf', 'true')
-        .query({ subCaseID: caseInfo.subCases![0].id })
+        .query({ subCaseId: caseInfo.subCases![0].id })
         .send(postCommentUserReq)
         .expect(200);
 

--- a/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/find_sub_cases.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/find_sub_cases.ts
@@ -74,7 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
         ...findSubCasesResp,
         total: 1,
         // find should not return the comments themselves only the stats
-        subCases: [{ ...caseInfo.subCase!, comments: [], totalComment: 1, totalAlerts: 2 }],
+        subCases: [{ ...caseInfo.subCases![0], comments: [], totalComment: 1, totalAlerts: 2 }],
         count_open_cases: 1,
       });
     });
@@ -101,7 +101,7 @@ export default ({ getService }: FtrProviderContext): void => {
             status: CaseStatuses.closed,
           },
           {
-            ...subCase2Resp.newSubCaseInfo.subCase,
+            ...subCase2Resp.newSubCaseInfo.subCases![0],
             comments: [],
             totalComment: 1,
             totalAlerts: 2,
@@ -157,8 +157,8 @@ export default ({ getService }: FtrProviderContext): void => {
         supertest,
         cases: [
           {
-            id: secondSub.subCase!.id,
-            version: secondSub.subCase!.version,
+            id: secondSub.subCases![0].id,
+            version: secondSub.subCases![0].version,
             status: CaseStatuses['in-progress'],
           },
         ],
@@ -231,8 +231,8 @@ export default ({ getService }: FtrProviderContext): void => {
         supertest,
         cases: [
           {
-            id: secondSub.subCase!.id,
-            version: secondSub.subCase!.version,
+            id: secondSub.subCases![0].id,
+            version: secondSub.subCases![0].version,
             status: CaseStatuses['in-progress'],
           },
         ],

--- a/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/get_sub_case.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/get_sub_case.ts
@@ -53,14 +53,16 @@ export default ({ getService }: FtrProviderContext): void => {
       const { newSubCaseInfo: caseInfo } = await createSubCase({ supertest, actionID });
 
       const { body }: { body: SubCaseResponse } = await supertest
-        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
         .set('kbn-xsrf', 'true')
         .send()
         .expect(200);
 
       expect(removeServerGeneratedPropertiesFromComments(body.comments)).to.eql(
         commentsResp({
-          comments: [{ comment: defaultCreateSubComment, id: caseInfo.subCase!.comments![0].id }],
+          comments: [
+            { comment: defaultCreateSubComment, id: caseInfo.subCases![0].comments![0].id },
+          ],
           associationType: AssociationType.subCase,
         })
       );
@@ -75,13 +77,13 @@ export default ({ getService }: FtrProviderContext): void => {
 
       const { body: singleAlert }: { body: CaseResponse } = await supertest
         .post(getCaseCommentsUrl(caseInfo.id))
-        .query({ subCaseID: caseInfo.subCases![0].id })
+        .query({ subCaseId: caseInfo.subCases![0].id })
         .set('kbn-xsrf', 'true')
         .send(postCommentAlertReq)
         .expect(200);
 
       const { body }: { body: SubCaseResponse } = await supertest
-        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
         .set('kbn-xsrf', 'true')
         .send()
         .expect(200);
@@ -89,7 +91,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(removeServerGeneratedPropertiesFromComments(body.comments)).to.eql(
         commentsResp({
           comments: [
-            { comment: defaultCreateSubComment, id: caseInfo.subCase!.comments![0].id },
+            { comment: defaultCreateSubComment, id: caseInfo.subCases![0].comments![0].id },
             {
               comment: postCommentAlertReq,
               id: singleAlert.subCases![0].comments![1].id,

--- a/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/patch_sub_cases.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/sub_cases/patch_sub_cases.ts
@@ -42,15 +42,15 @@ export default function ({ getService }: FtrProviderContext) {
         supertest,
         cases: [
           {
-            id: caseInfo.subCase!.id,
-            version: caseInfo.subCase!.version,
+            id: caseInfo.subCases![0].id,
+            version: caseInfo.subCases![0].version,
             status: CaseStatuses['in-progress'],
           },
         ],
         type: 'sub_case',
       });
       const { body: subCase }: { body: SubCaseResponse } = await supertest
-        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCase!.id))
+        .get(getSubCaseDetailsUrl(caseInfo.id, caseInfo.subCases![0].id))
         .expect(200);
 
       expect(subCase.status).to.eql(CaseStatuses['in-progress']);
@@ -81,8 +81,8 @@ export default function ({ getService }: FtrProviderContext) {
         .send({
           subCases: [
             {
-              id: caseInfo.subCase!.id,
-              version: caseInfo.subCase!.version,
+              id: caseInfo.subCases![0].id,
+              version: caseInfo.subCases![0].version,
               type: 'blah',
             },
           ],

--- a/x-pack/test/case_api_integration/common/lib/mock.ts
+++ b/x-pack/test/case_api_integration/common/lib/mock.ts
@@ -26,7 +26,6 @@ import {
   CaseClientPostRequest,
   SubCaseResponse,
   AssociationType,
-  CollectionWithSubCaseResponse,
   SubCasesFindResponse,
   CommentRequest,
 } from '../../../../plugins/case/common/api';
@@ -159,18 +158,17 @@ export const subCaseResp = ({
 
 interface FormattedCollectionResponse {
   caseInfo: Partial<CaseResponse>;
-  subCase?: Partial<SubCaseResponse>;
+  subCases?: Array<Partial<SubCaseResponse>>;
   comments?: Array<Partial<CommentResponse>>;
 }
 
-export const formatCollectionResponse = (
-  caseInfo: CollectionWithSubCaseResponse
-): FormattedCollectionResponse => {
+export const formatCollectionResponse = (caseInfo: CaseResponse): FormattedCollectionResponse => {
+  const subCase = removeServerGeneratedPropertiesFromSubCase(caseInfo.subCases?.[0]);
   return {
     caseInfo: removeServerGeneratedPropertiesFromCaseCollection(caseInfo),
-    subCase: removeServerGeneratedPropertiesFromSubCase(caseInfo.subCase),
+    subCases: subCase ? [subCase] : undefined,
     comments: removeServerGeneratedPropertiesFromComments(
-      caseInfo.subCase?.comments ?? caseInfo.comments
+      caseInfo.subCases?.[0].comments ?? caseInfo.comments
     ),
   };
 };
@@ -187,10 +185,10 @@ export const removeServerGeneratedPropertiesFromSubCase = (
 };
 
 export const removeServerGeneratedPropertiesFromCaseCollection = (
-  config: Partial<CollectionWithSubCaseResponse>
-): Partial<CollectionWithSubCaseResponse> => {
+  config: Partial<CaseResponse>
+): Partial<CaseResponse> => {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { closed_at, created_at, updated_at, version, subCase, ...rest } = config;
+  const { closed_at, created_at, updated_at, version, subCases, ...rest } = config;
   return rest;
 };
 

--- a/x-pack/test/case_api_integration/common/lib/utils.ts
+++ b/x-pack/test/case_api_integration/common/lib/utils.ts
@@ -16,7 +16,7 @@ import {
   CaseConnector,
   ConnectorTypes,
   CasePostRequest,
-  CollectionWithSubCaseResponse,
+  CaseResponse,
   SubCasesFindResponse,
   CaseStatuses,
   SubCasesResponse,
@@ -68,7 +68,7 @@ export const defaultCreateSubPost = postCollectionReq;
  * Response structure for the createSubCase and createSubCaseComment functions.
  */
 export interface CreateSubCaseResp {
-  newSubCaseInfo: CollectionWithSubCaseResponse;
+  newSubCaseInfo: CaseResponse;
   modifiedSubCases?: SubCasesResponse;
 }
 


### PR DESCRIPTION
This PR gets the integration tests working based on the `subCaseID -> subCaseId` change and removal of the Collection response type.